### PR TITLE
Remove previous backup files

### DIFF
--- a/linux-install/backup.sh
+++ b/linux-install/backup.sh
@@ -26,6 +26,7 @@ tsm settings export -f "${settings_backup}"
 
 content_backup_target_dir="/var/opt/tableau/tableau_server/data/tabsvc/files/backups"
 content_backup_file="backup.tsbak"
+rm -f "${content_backup_target_dir}/${content_backup_file}"
 say "Exporting content to ${content_backup_file}"
 tsm maintenance backup -f "${content_backup_file}" --multithreaded
 mv "${content_backup_target_dir}/${content_backup_file}" "${backup_dir}"


### PR DESCRIPTION
When backup files are created but for some reason not moved to the target backup directory, these files prevent new backups from executing. This commit makes sure the file is deleted if it exists.